### PR TITLE
[Design] 임시 글 목록 페이지 UI 구현

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,9 +4,12 @@ import Logo from '@components/Logo'
 import { Package, Search } from 'lucide-react'
 import { fontWeight } from '@/constants/font'
 import colors from '@/constants/color'
+import { useNavigate } from 'react-router-dom'
 
 const Header = () => {
 	const [userName, setUserName] = useState<string>('박지영')
+	const navigate = useNavigate()
+
 	return (
 		<Container>
 			<Logo logoWidth={160} clickable={true} />
@@ -15,7 +18,13 @@ const Header = () => {
 					<Search className="search-icon" strokeWidth={1.5} color={colors.commentGray} size={16} />
 					<input type="text" placeholder="검색" />
 				</SearchForm>
-				<Package strokeWidth={2} className="box-icon" />
+				<Package
+					strokeWidth={2}
+					className="box-icon"
+					onClick={() => {
+						navigate('/saves')
+					}}
+				/>
 				<div className="user-name">
 					안녕하세요, <span>{userName}</span>님!
 				</div>

--- a/src/pages/Saves.tsx
+++ b/src/pages/Saves.tsx
@@ -1,0 +1,113 @@
+import React from 'react'
+import styled from '@emotion/styled'
+import { fontSize, fontWeight } from '@/constants/font'
+import { Trash2 } from 'lucide-react'
+import colors from '@/constants/color'
+
+const savesContent = [
+	{
+		id: 1,
+		date: '2024년 9월 12일',
+		title: '날짜 형식 변환',
+		content:
+			'안녕하세요 안녕하세요 안녕하세요 안녕하세요 안녕하세요 안녕하세요 안녕하세요 안녕하세요 안녕하세요 ',
+	},
+	{
+		id: 2,
+		date: '2024년 9월 12일',
+		title: '하츄핑',
+		content:
+			'오 대박 로봇 대박 어떡해 대박 이러한 기술들은 로봇을 포함한 다양한 NVIDIA 하드웨어 기반 컴퓨터에 응용할 수 있습니다.',
+	},
+	{
+		id: 3,
+		date: '2024년 9월 12일',
+		title: '날짜 형식 변환',
+		content:
+			'안녕하세요 안녕하세요 안녕하세요 안녕하세요 안녕하세요 안녕하세요 안녕하세요 안녕하세요 안녕하세요 ',
+	},
+	{
+		id: 4,
+		date: '2024년 9월 12일',
+		title: '하츄핑',
+		content:
+			'오 대박 로봇 대박 어떡해 대박 이러한 기술들은 로봇을 포함한 다양한 NVIDIA 하드웨어 기반 컴퓨터에 응용할 수 있습니다.',
+	},
+]
+
+const Saves = () => {
+	return (
+		<Container>
+			<div className="title">임시 글 목록</div>
+			<SaveContainer>
+				<ul className="save">
+					{savesContent.map(({ id, date, title, content }) => (
+						<li key={id} className="save-list">
+							<div className="save-title">{title}</div>
+							<div className="save-content">{content}</div>
+							<div className="last-container">
+								<span>{date}</span>
+								<span className="delete">
+									<Trash2 strokeWidth={1} size={20} />
+									삭제
+								</span>
+							</div>
+						</li>
+					))}
+				</ul>
+			</SaveContainer>
+		</Container>
+	)
+}
+
+const Container = styled.div`
+	width: 100%;
+	height: 100vh;
+	padding: 0 400px;
+
+	.title {
+		font-size: 64px;
+		font-weight: ${fontWeight.extraBold};
+		margin: 100px 0;
+	}
+`
+
+const SaveContainer = styled.div`
+	width: 824px;
+
+	.save-list {
+		border-bottom: 1px solid ${colors.commentBlack};
+		margin-bottom: 52px;
+	}
+
+	.save-title {
+		font-size: ${fontSize.xxxxl};
+		font-weight: ${fontWeight.semiBold};
+		margin-bottom: 38px;
+	}
+
+	.save-content {
+		font-size: ${fontSize.lg};
+		line-height: 1.2;
+		margin-bottom: 18px;
+	}
+
+	.last-container {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: 20px;
+		color: ${colors.commentGray};
+	}
+
+	.delete {
+		display: flex;
+		align-items: center;
+		cursor: pointer;
+
+		&:hover {
+			color: ${colors.white};
+		}
+	}
+`
+export default Saves

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -3,6 +3,7 @@ import Layout from '@/layout/Layout'
 import ErrorPage from '@/pages/ErrorPage'
 import Home from '@/pages/Home'
 import Login from '@/pages/Login'
+import Saves from '@/pages/Saves'
 
 export const router = createBrowserRouter([
 	{
@@ -17,6 +18,10 @@ export const router = createBrowserRouter([
 			{
 				path: '/login',
 				element: <Login />, // 로그인 페이지 (헤더 없음)
+			},
+			{
+				path: '/saves',
+				element: <Saves />,
 			},
 		],
 	},


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

임시 글 목록 페이지 UI 구현

## 📋 작업 내용

- 임시 글 목록 페이지 라우팅 설정 (/saves)
- Header box-icon 클릭시 임시 글 목록 페이지로 이동
- 임시 글 목록 페이지 UI 구현

## 🔧 변경 사항

위와 같습니다.

## 📸 스크린샷 (선택 사항)

<img width="1785" alt="image" src="https://github.com/user-attachments/assets/5b6eee45-973b-4173-933e-13c52d66f313">

## 📄 기타

추후 max-width, padding 값 정해지면 수정 예정
