### PR TITLE
[Fix] 마크다운 이미지 형식 렌더링되도록 수정 

### DIFF
--- a/src/components/RenderMarkdown.tsx
+++ b/src/components/RenderMarkdown.tsx
@@ -25,6 +25,7 @@ const RenderMarkdown = ({ markdown }: MarkdownProps) => {
 				children={markdown}
 				remarkPlugins={[remarkGfm, remarkBreaks]} // github에서 제공, 테이블이, 링크, 체크리스트 등이 추가된 플러그인
 				rehypePlugins={[rehypeRaw]} // <html 태그 사용할 수 있도록 하는 플러그인
+				urlTransform={(value: string) => value}
 				components={{
 					code({ className, children, ...props }: CodeProps) {
 						const match = /language-(\w+)/.exec(className || '')
@@ -81,12 +82,16 @@ const RenderMarkdown = ({ markdown }: MarkdownProps) => {
 							</pre>
 						)
 					},
-					img({ alt, src, ...props }) {
+					img({ ...props }) {
 						return (
 							<img
-								src={src}
-								alt={alt}
-								style={{ maxWidth: '50%', justifyContent: 'center' }}
+								style={{
+									maxWidth: '50%',
+									justifyContent: 'center',
+									alignItems: 'center',
+									display: 'flex',
+									margin: '0 auto',
+								}}
 								{...props}
 							/>
 						)

--- a/src/styles/GlobalStyles.tsx
+++ b/src/styles/GlobalStyles.tsx
@@ -167,6 +167,7 @@ const GlobalStyles = () => (
 				padding: 1em;
 				margin-bottom: 20px;
 			}
+			textarea,
 			#root {
 				width: 100%;
 				height: 100%;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

- 글 작성 페이지 css 수정
- 파일탐색기 통해서 이미지 업로드 했을 때 나오는 base64로 인코딩 된 형식의 이미지 주소는 마크다운 라이브러리에서 보안상의 문제로 지원하지 않는다는 이슈 발견
(킹 받아서 일단.. 벨로그 참고하러감.. 벨로그도 보니까 이미지 업로드 중일 때 url이 blob 형식으로 나오면서 바뀌길래 나도 blob으로 로컬에 있는 이미지를 임시 url로 변환해서 마크다운 형식으로 렌더링 되도록 어찌저찌 꼼수 써놧음 api 나오면 다시 바꿔야함)
- 글 작성 섹션, 작성시 확인할 수 있는 섹션 각각 스크롤 적용
- 나가기 클릭했을 때 navigate(-1) 처리 해놨음


## 📸 스크린샷 (선택 사항)
![image](https://github.com/user-attachments/assets/8086deb8-fd3c-4356-8ea3-20a22aaaacd8)
![image](https://github.com/user-attachments/assets/45769c54-f9eb-421d-80ab-a64554605dd8)


