### PR TITLE
[Feature] 헤더에 로그인 정보 받아오기

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,13 +1,13 @@
-import React, { useState } from 'react'
 import styled from '@emotion/styled'
 import Logo from '@components/Logo'
-import { Package, Search } from 'lucide-react'
+import { Package, Search, User } from 'lucide-react'
 import { fontWeight } from '@/constants/font'
 import colors from '@/constants/color'
 import { useNavigate } from 'react-router-dom'
+import { useAuthStore } from '@/stores/authStore'
 
 const Header = () => {
-	const [userName, setUserName] = useState<string>('박지영')
+	const { isLogin, userId } = useAuthStore()
 	const navigate = useNavigate()
 
 	return (
@@ -18,16 +18,27 @@ const Header = () => {
 					<Search className="search-icon" strokeWidth={1.5} color={colors.commentGray} size={16} />
 					<input type="text" placeholder="검색" />
 				</SearchForm>
-				<Package
-					strokeWidth={2}
-					className="box-icon"
-					onClick={() => {
-						navigate('/saves')
-					}}
-				/>
-				<div className="user-name">
-					안녕하세요, <span>{userName}</span>님!
-				</div>
+				{isLogin && (
+					<>
+						<Package
+							strokeWidth={2}
+							className="box-icon"
+							onClick={() => {
+								navigate('/saves')
+							}}
+						/>
+						<div className="user-name">
+							안녕하세요, <span>{userId}</span>님!
+						</div>
+					</>
+				)}
+
+				{!isLogin && (
+					<div className="login" onClick={() => navigate('/login')}>
+						<User strokeWidth={2.5} style={{ marginRight: '8px' }} />
+						Login
+					</div>
+				)}
 			</div>
 		</Container>
 	)
@@ -57,6 +68,18 @@ const Container = styled.div`
 		font-weight: ${fontWeight.bold};
 
 		span {
+			margin-left: 2px;
+			color: ${colors.primaryBlue};
+		}
+	}
+
+	.login {
+		display: flex;
+		align-items: center;
+		font-weight: ${fontWeight.semiBold};
+		cursor: pointer;
+
+		&:hover {
 			color: ${colors.primaryBlue};
 		}
 	}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -5,19 +5,21 @@ import Logo from '@components/Logo'
 import { fontSize, fontWeight } from '@/constants/font'
 import { useNavigate } from 'react-router-dom'
 import axios from 'axios'
+import { useAuthStore } from '@/stores/authStore'
 
 const Login: React.FC = () => {
 	const [id, setId] = useState('')
 	const [pw, setPw] = useState('')
 	const [error, setError] = useState(false)
 	const navigate = useNavigate()
+	const login = useAuthStore((state) => state.login)
 
 	const handleLogin = async (e: React.FormEvent<HTMLFormElement>) => {
 		e.preventDefault()
 		await getUser()
 	}
 
-	async function getUser() {
+	const getUser = async () => {
 		try {
 			await axios.post(
 				'http://nubble-backend-eb-1-env.eba-f5sb82hp.ap-northeast-2.elasticbeanstalk.com/sessions',
@@ -32,10 +34,26 @@ const Login: React.FC = () => {
 					withCredentials: true,
 				},
 			)
-			// console.log('로그인 성공!!!!!!!!!!!!!!!')
+			console.log('로그인 성공!!!!!!!!!!!!!!!')
+			login()
+			await checkSessionStatus()
 			navigate('/')
 		} catch {
 			setError(true)
+		}
+	}
+
+	const checkSessionStatus = async () => {
+		try {
+			await axios.get(
+				'http://nubble-backend-eb-1-env.eba-f5sb82hp.ap-northeast-2.elasticbeanstalk.com/sessions/validate',
+				{
+					withCredentials: true,
+				},
+			)
+			console.log('로그인 된 상태')
+		} catch (error) {
+			console.error('로그인 안됨 ㅠㅠ', error)
 		}
 	}
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -35,7 +35,7 @@ const Login: React.FC = () => {
 				},
 			)
 			console.log('로그인 성공!!!!!!!!!!!!!!!')
-			login()
+			login(id)
 			await checkSessionStatus()
 			navigate('/')
 		} catch {

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -2,10 +2,12 @@ import { create } from 'zustand'
 
 interface AuthState {
 	isLogin: boolean
-	login: () => void
+	userId: string | null
+	login: (id: string) => void
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
 	isLogin: false,
-	login: () => set({ isLogin: true }),
+	userId: null,
+	login: (id: string) => set({ isLogin: true, userId: id }),
 }))

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand'
+
+interface AuthState {
+	isLogin: boolean
+	login: () => void
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+	isLogin: false,
+	login: () => set({ isLogin: true }),
+}))


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

헤더에 로그인 정보 받아오기

## 📋 작업 내용

- authStore에 userId값 추가해서 id 받아오기
- 회원/비회원 화면 처리

## 🔧 변경 사항

위와 같습니다.

## 📸 스크린샷 (선택 사항)

로그아웃
![image](https://github.com/user-attachments/assets/cbc94f86-0d9e-45aa-99a2-93d5aae3853f)

로그인
![image](https://github.com/user-attachments/assets/a0c83fcc-7521-4695-b551-453610164300)


## 📄 기타

추후 db에 userName 추가되면 userName으로 수정 예정
