### PR TITLE
[Feature] 로그인 상태 유지 구현

### DIFF
--- a/src/hooks/useCheckSession.ts
+++ b/src/hooks/useCheckSession.ts
@@ -1,0 +1,26 @@
+import axios from 'axios'
+import { useEffect } from 'react'
+
+const useCheckSession = () => {
+	useEffect(() => {
+		const checkSessionStatus = async () => {
+			try {
+				await axios.get(
+					'http://nubble-backend-eb-1-env.eba-f5sb82hp.ap-northeast-2.elasticbeanstalk.com/auth/sessions/validate',
+					{
+						withCredentials: true,
+					},
+				)
+				console.log('로그인 된 상태')
+			} catch (error) {
+				console.error('로그인 안됨 ㅠㅠ', error)
+				localStorage.removeItem('sessionId')
+				localStorage.removeItem('id')
+			}
+		}
+
+		checkSessionStatus()
+	}, [])
+}
+
+export default useCheckSession

--- a/src/hooks/useCheckSession.ts
+++ b/src/hooks/useCheckSession.ts
@@ -5,12 +5,22 @@ const useCheckSession = () => {
 	useEffect(() => {
 		const checkSessionStatus = async () => {
 			try {
+				const sessionId = localStorage.getItem('sessionId')
+
+				if (!sessionId) {
+					console.error('세션 ID가 없습니다.')
+					return
+				}
+
 				await axios.get(
 					'http://nubble-backend-eb-1-env.eba-f5sb82hp.ap-northeast-2.elasticbeanstalk.com/auth/sessions/validate',
 					{
-						withCredentials: true,
+						headers: {
+							'SESSION-ID': sessionId,
+						},
 					},
 				)
+
 				console.log('로그인 된 상태')
 			} catch (error) {
 				console.error('로그인 안됨 ㅠㅠ', error)

--- a/src/pages/ErrorPage.tsx
+++ b/src/pages/ErrorPage.tsx
@@ -1,4 +1,5 @@
 import { useRouteError } from 'react-router-dom'
+import React from 'react'
 
 const ErrorPage: React.FC = () => {
 	const error = useRouteError()

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -6,6 +6,7 @@ import colors from '@/constants/color'
 import { fontSize, fontWeight } from '@/constants/font'
 import { useNavigate } from 'react-router-dom'
 import { useAuthStore } from '@/stores/authStore'
+import useCheckSession from '@/hooks/useCheckSession'
 
 const postData = [
 	{
@@ -67,6 +68,7 @@ const postData = [
 ]
 
 const Home: React.FC = () => {
+	useCheckSession()
 	const { isLogin } = useAuthStore()
 	const navigate = useNavigate()
 	return (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -213,7 +213,7 @@ const PostContainer = styled.div`
 			color: ${colors.commentGray};
 			margin-bottom: 20px;
 
-			div:first-child::after {
+			div:first-of-type::after {
 				content: '•';
 				margin: 0 8px;
 			}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -21,8 +21,8 @@ const Login: React.FC = () => {
 
 	const getUser = async () => {
 		try {
-			await axios.post(
-				'http://nubble-backend-eb-1-env.eba-f5sb82hp.ap-northeast-2.elasticbeanstalk.com/sessions',
+			const res = await axios.post(
+				'http://nubble-backend-eb-1-env.eba-f5sb82hp.ap-northeast-2.elasticbeanstalk.com/auth/sessions',
 				{
 					username: id,
 					password: pw,
@@ -34,26 +34,17 @@ const Login: React.FC = () => {
 					withCredentials: true,
 				},
 			)
+
+			const sessionId = res.data.sessionId
+
+			console.log(res)
+			localStorage.setItem('sessionId', sessionId)
+			localStorage.setItem('userId', id)
 			console.log('로그인 성공!!!!!!!!!!!!!!!')
-			login(id)
-			await checkSessionStatus()
+			login(sessionId, id)
 			navigate('/')
 		} catch {
 			setError(true)
-		}
-	}
-
-	const checkSessionStatus = async () => {
-		try {
-			await axios.get(
-				'http://nubble-backend-eb-1-env.eba-f5sb82hp.ap-northeast-2.elasticbeanstalk.com/sessions/validate',
-				{
-					withCredentials: true,
-				},
-			)
-			console.log('로그인 된 상태')
-		} catch (error) {
-			console.error('로그인 안됨 ㅠㅠ', error)
 		}
 	}
 

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -2,12 +2,18 @@ import { create } from 'zustand'
 
 interface AuthState {
 	isLogin: boolean
+	sessionId: string | null
 	userId: string | null
-	login: (id: string) => void
+	login: (sessionId: string, userId: string) => void
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
-	isLogin: false,
-	userId: null,
-	login: (id: string) => set({ isLogin: true, userId: id }),
+	isLogin: localStorage.getItem('sessionId') ? true : false,
+	sessionId: localStorage.getItem('sessionId'),
+	userId: localStorage.getItem('userId'),
+	login: (sessionId: string, userId: string) => {
+		localStorage.setItem('sessionId', sessionId)
+		localStorage.setItem('userId', userId)
+		set({ isLogin: true, sessionId, userId })
+	},
 }))


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

로그인 상태 유지 구현

## 📋 작업 내용

- 서버에서 sessionId만 받아서 로컬스토리지로 관리
- 세션 검증 함수 별도의 훅으로 분리
- 새로고침해도 로그인 유지

## 🔧 변경 사항

위와 같습니다.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

- 로그인 유무 -> authStore.ts -> isLogin
- 세션 검증 함수 -> 쓰고싶은 페이지에 `useCheckSession()`
- 콘솔로그 부분은 개발 다 끝나고 지우겠습니다 ^^
- 로그아웃하려면 로컬스토리지에서 userId, sessionId 둘 다 지워줘야함
- 추후 로그아웃 추가 ^^..
