### PR TITLE
[Feat] 파일 업로드 api 적용

### DIFF
--- a/src/hooks/useCategory.ts
+++ b/src/hooks/useCategory.ts
@@ -1,0 +1,26 @@
+import React, { useState } from 'react'
+
+const useCategory = () => {
+	const [selectedCategory, setSelectedCategory] = useState<string>('')
+	const [selectedSubCategory, setSelectedSubCategory] = useState<string>('')
+
+	const handleSelectedData = (e: React.ChangeEvent<HTMLSelectElement>) => {
+		setSelectedCategory(e.target.value)
+		setSelectedSubCategory('')
+	}
+
+	const handleSubData = (e: React.ChangeEvent<HTMLSelectElement>) => {
+		setSelectedSubCategory(e.target.value)
+	}
+
+	return {
+		selectedCategory,
+		selectedSubCategory,
+		setSelectedCategory,
+		setSelectedSubCategory,
+		handleSelectedData,
+		handleSubData,
+	}
+}
+
+export default useCategory

--- a/src/hooks/useFileUpload.ts
+++ b/src/hooks/useFileUpload.ts
@@ -1,0 +1,34 @@
+import { useState } from 'react'
+import axios from 'axios'
+
+const useFileUpload = () => {
+	const [failed, setFailed] = useState('')
+	const sessionId = localStorage.getItem('sessionId')
+
+	const uploadFile = async (file: File) => {
+		try {
+			const formData = new FormData()
+			formData.append('file', file)
+
+			const res = await axios.post(
+				`http://nubble-backend-eb-1-env.eba-f5sb82hp.ap-northeast-2.elasticbeanstalk.com/files`,
+				formData,
+				{
+					headers: {
+						'Content-Type': 'multipart/form-data',
+						'SESSION-ID': sessionId,
+					},
+				},
+			)
+			return res.data
+		} catch (error) {
+			setFailed('파일 업로드 실패')
+		}
+	}
+
+	return {
+		uploadFile,
+	}
+}
+
+export default useFileUpload


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

기존 : 파일 업로드 시 이미지 url을 임시로 blob 처리 후 마크다운 형식으로 렌더링 
변경 : **base64 형식의 이미지 파일을 서버에 전송한 후 해당 이미지에 맞는 링크를 받아와서 렌더링할 수 있도록 변경**

이미지 복붙도 동일한 로직으로 업로드 됨

## 🔧 변경 사항

- 파일 업로드 후 이미지 링크로 변환하는 로직 훅으로 분리
- 카테고리 훅으로 분리

## 📸 스크린샷 (선택 사항)

![스크린샷 2024-10-08 오후 3 55 27](https://github.com/user-attachments/assets/80412572-7545-4562-84ac-96e6e4ba8223)

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
