### PR TITLE
[fix] 한글 디코딩 (#74)

### DIFF
--- a/src/hooks/useCoteData.ts
+++ b/src/hooks/useCoteData.ts
@@ -98,7 +98,9 @@ const getFileContents = async (userId: string, title: string): Promise<FileConte
 		const fileData = await fileRes.data
 
 		//js 파일 내 문제풀이 (atob를 통해 base64로 되어있는 문제풀이 디코딩해서 문자열로 변환)
-		const content = atob(fileData.content.replace(/\n/g, ''))
+		const content = new TextDecoder('utf-8').decode(
+			new Uint8Array([...atob(fileData.content.replace(/\n/g, ''))].map((c) => c.charCodeAt(0))),
+		)
 		const commitDate = await getFileCommitInfo(userId, fileMatch.path)
 		const date = commitDate
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

한글 깨져서 나오는 현상 발생 . . .

## 📋 작업 내용

한글로 달려있는 주석 부분 깨지지 않고 제대로 렌더링 되도록 수정

atob  -> base64형식으로 인코딩 되어있는 문자열을 디코딩 시켜서 일반 문자열로 변환
unit8Array -> 문자 하나씩 utf-8 형식으로 변환시켜줘야하기 때문에 atob로 디코딩된 문자열을 문자열 배열로 변환
TextDecoder('utf-8') -> 디코딩 된 문자를 하나씩 가져와서 utf-8 형식으로 변환


## 📸 스크린샷 (선택 사항)

![스크린샷 2024-10-09 오후 5 09 35](https://github.com/user-attachments/assets/a0da92a0-f654-48a8-bc9d-58353aae4c13)
수정 이후
![스크린샷 2024-10-09 오후 5 19 24](https://github.com/user-attachments/assets/3ded6e5f-de17-4894-9390-18c9a966eb3a)


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
