### PR TITLE
[Feat] 글쓰기 페이지 -> 미리보기 페이지 이동

### DIFF
--- a/src/components/SelectBox.tsx
+++ b/src/components/SelectBox.tsx
@@ -1,5 +1,6 @@
 import { ChangeEvent } from 'react'
 import styled from '@emotion/styled'
+import colors from '@/constants/color'
 
 interface SelectBoxProps {
 	label?: string
@@ -40,10 +41,11 @@ const Label = styled.label`
 `
 
 const Select = styled.select`
-	height: 30px;
+	height: 33px;
 	width: 100%;
 	border-radius: 8px;
-	padding-left: 12px;
+	padding: 0 10px;
+	color: ${colors.commentGray};
 `
 
 const Option = styled.option``

--- a/src/hooks/useGoBack.ts
+++ b/src/hooks/useGoBack.ts
@@ -1,0 +1,15 @@
+import React from 'react'
+import { useNavigate } from 'react-router-dom'
+
+const useGoBack = () => {
+	const navigate = useNavigate()
+
+	const handleBack = (e: React.MouseEvent) => {
+		e.preventDefault()
+		navigate(-1)
+	}
+
+	return handleBack
+}
+
+export default useGoBack

--- a/src/pages/PreviewPage.tsx
+++ b/src/pages/PreviewPage.tsx
@@ -4,14 +4,15 @@ import { ImagePlus } from 'lucide-react'
 import colors from '@/constants/color'
 import { fontSize, fontWeight } from '@/constants/font'
 import Button from '@components/Button'
-
-const postData = {
-	title: '언어모델 로봇 ML',
-	content:
-		'오늘날 머신러닝(machine learning, ML) 모델 개발은 대부분 NVIDIA의 데이터센터 GPU(예: A100)나 워크스테이션 GPU(예: RTX4090)가 장착된 고성능 서버 환경에서 이루어집니다. ',
-}
+import { useWriteStore } from '@/stores/writeStore'
+import useGoBack from '@/hooks/useGoBack'
 
 const PreviewPage = () => {
+	const title = useWriteStore((state) => state.title)
+	const content = useWriteStore((state) => state.content)
+	const thumbnail = useWriteStore((state) => state.thumbnailImg)
+	const handleBack = useGoBack()
+
 	return (
 		<Container>
 			<Title>게시물 미리보기</Title>
@@ -21,25 +22,35 @@ const PreviewPage = () => {
 						<span>재업로드</span>
 						<span>제거</span>
 					</div>
-					<div className="thumnail-upload">
-						<ImagePlus size={200} strokeWidth={1} color={colors.deleteGray} />
-						<form>
-							<label htmlFor="thumnailImg" className="img-label">
-								썸네일 업로드
-							</label>
-							<input type="file" accept="image/*" id="profileImg" className="img-input" />
-						</form>
+					<div
+						className="thumnail-upload"
+						style={{
+							backgroundImage: thumbnail ? `url(${thumbnail})` : 'none',
+							backgroundSize: 'cover',
+							backgroundPosition: 'center',
+						}}
+					>
+						{!thumbnail ? (
+							<ImagePlus size={200} strokeWidth={1} color={colors.deleteGray} />
+						) : (
+							<form>
+								<label htmlFor="thumbnailImg" className="img-label">
+									썸네일 업로드
+								</label>
+								<input type="file" accept="image/*" id="thumbnailImg" className="img-input" />
+							</form>
+						)}
 					</div>
 				</ThumnailContainer>
 				<Line />
 				<PostPreviewContainer>
-					<div className="post-title">{postData.title}</div>
-					<textarea defaultValue={postData.content} className="post-content" />
-					<span className="count">{postData.content.length}/150</span>
+					<div className="post-title">{title}</div>
+					<textarea defaultValue={content} className="post-content" />
+					<span className="count">{content.length}/150</span>
 				</PostPreviewContainer>
 			</PreviewContainer>
 			<ButtonContainer>
-				<Button variant="secondary" radius={50}>
+				<Button variant="secondary" radius={50} onClick={handleBack}>
 					취소
 				</Button>
 				<Button radius={50}>등록하기</Button>

--- a/src/pages/WritePage.tsx
+++ b/src/pages/WritePage.tsx
@@ -56,6 +56,7 @@ const WritePage = () => {
 	const [markdownContent, setMarkdownContent] = useState('')
 	const [title, setTitle] = useState('')
 	const [isEditing, setIsEditing] = useState(false)
+
 	const {
 		selectedCategory,
 		selectedSubCategory,
@@ -121,27 +122,25 @@ const WritePage = () => {
 
 	const handleSubmit = async () => {
 		try {
-			if (title && markdownContent) {
-				const res = await axios.post(
-					`http://nubble-backend-eb-1-env.eba-f5sb82hp.ap-northeast-2.elasticbeanstalk.com/posts`,
-					{
-						title,
-						content: markdownContent,
+			const res = await axios.post(
+				`http://nubble-backend-eb-1-env.eba-f5sb82hp.ap-northeast-2.elasticbeanstalk.com/posts`,
+				{
+					title,
+					content: markdownContent,
+				},
+				{
+					headers: {
+						'Content-Type': 'application/json',
+						'SESSION-ID': sessionId,
 					},
-					{
-						headers: {
-							'Content-Type': 'application/json',
-							'SESSION-ID': sessionId,
-						},
-					},
-				)
-				setTitle('')
-				setMarkdownContent('')
-				setSelectedCategory('')
-				setSelectedSubCategory('')
-				navigate('/preview')
-				return res.data
-			}
+				},
+			)
+			setTitle('')
+			setMarkdownContent('')
+			setSelectedCategory('')
+			setSelectedSubCategory('')
+			navigate('/preview')
+			return res.data
 		} catch (error) {
 			console.log('글 등록 error', error)
 		}
@@ -212,13 +211,13 @@ const WritePage = () => {
 						나가기
 					</IconButton>
 					<div className="area-button">
-						<Button variant="secondary" radius={50}>
+						<Button variant="secondary" radius={50} disabled={!(title && markdownContent)}>
 							임시저장
 						</Button>
 						{isEditing ? (
 							<Button radius={50}>수정하기</Button>
 						) : (
-							<Button radius={50} onClick={handleSubmit}>
+							<Button radius={50} onClick={handleSubmit} disabled={!(title && markdownContent)}>
 								등록하기
 							</Button>
 						)}
@@ -345,6 +344,11 @@ const Container = styled.div`
 		background-color: ${colors.mainGray};
 		left: 0;
 		bottom: 0;
+
+		.area-button {
+			display: flex;
+			gap: 10px;
+		}
 	}
 `
 const IconButton = styled.button`

--- a/src/stores/writeStore.ts
+++ b/src/stores/writeStore.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand'
+
+interface previewState {
+	title: string
+	thumbnailImg: string
+	content: string
+	setTitle: (newTitle: string) => void
+	setThumbnail: (newContent: string) => void
+	setContent: (newContent: string) => void
+}
+
+export const usePreviewStore = create<previewState>((set) => ({
+	title: '',
+	thumbnailImg: '',
+	content: '',
+	setTitle: (newTitle) => set({ title: newTitle }),
+	setContent: (newContent) => set({ content: newContent }),
+	setThumbnail: (newContent) => {
+		const match = newContent.match(/!\[\]\((.*?)\)/)
+		const newThumbnail = match && match[1] ? match[1] : ''
+		set((state) => {
+			if (state.thumbnailImg !== newThumbnail) {
+				return { thumbnailImg: newThumbnail }
+			}
+			return state
+		})
+	},
+}))


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

글쓰기 페이지에서 작성 된 제목, 내용, 썸네일 상태관리 store 생성
뒤로가기 로직 훅으로 분리

## 🔧 변경 사항
제목, 내용 입력값 없을 시 버튼 비활성화
등록하기 클릭 시 바로 서버에 등록 요청 -> 등록하기 클릭 시 서버에 등록 x, 미리보기 페이지로 이동
나가기 클릭 시 작성 중인 데이터 리셋

## 📸 스크린샷 (선택 사항)

![Oct-09-2024 20-34-04](https://github.com/user-attachments/assets/876bf62f-7d3d-4f31-ac50-8fb1430a8f08)


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
