### PR TITLE
[feat] 카테고리 api적용

### DIFF
--- a/src/components/SelectBox.tsx
+++ b/src/components/SelectBox.tsx
@@ -2,9 +2,19 @@ import { ChangeEvent } from 'react'
 import styled from '@emotion/styled'
 import colors from '@/constants/color'
 
+export interface categoryProps {
+	categoryId: string
+	categoryName: string
+}
+
+export interface boardProps {
+	id: string
+	name: string
+}
+
 interface SelectBoxProps {
 	label?: string
-	options: { key: string; value: string }[]
+	options: categoryProps[] | boardProps[]
 	placeholder?: string
 	selectedValue: string
 	disabled?: boolean
@@ -25,9 +35,16 @@ const SelectBox = ({
 			<Select value={selectedValue} onChange={handleChange} disabled={disabled}>
 				<Option value="">{placeholder}</Option>
 				{options.map((option) => (
-					<Option key={`select_${option.key}`} value={option.key}>
-						{option.value}
-					</Option>
+					<option
+						key={
+							'categoryId' in option
+								? `${option.categoryName}-${option.categoryId}`
+								: `${option.name}-${option.id}`
+						}
+						value={'categoryId' in option ? option.categoryId : option.id}
+					>
+						{'categoryName' in option ? option.categoryName : option.name}
+					</option>
 				))}
 			</Select>
 		</div>

--- a/src/stores/writeStore.ts
+++ b/src/stores/writeStore.ts
@@ -1,18 +1,25 @@
+import { boardProps, categoryProps } from '@components/SelectBox'
 import { create } from 'zustand'
 
 interface writeState {
 	title: string
 	thumbnailImg: string
 	content: string
+	category: categoryProps[]
+	board: boardProps[]
 	setTitle: (newTitle: string) => void
 	setThumbnail: (newContent: string) => void
 	setContent: (newContent: string) => void
+	setCategory: (newCategory: categoryProps[]) => void
+	setBoard: (newBoard: boardProps[]) => void
 }
 
 export const useWriteStore = create<writeState>((set) => ({
 	title: '',
 	thumbnailImg: '',
 	content: '',
+	category: [],
+	board: [],
 	setTitle: (newTitle) => set({ title: newTitle }),
 	setContent: (newContent) => set({ content: newContent }),
 	setThumbnail: (newContent) => {
@@ -25,4 +32,12 @@ export const useWriteStore = create<writeState>((set) => ({
 			return state
 		})
 	},
+	setCategory: (newCategory) =>
+		set((state) => {
+			return { ...state, category: newCategory }
+		}),
+	setBoard: (newBoard) =>
+		set((state) => {
+			return { ...state, board: newBoard }
+		}),
 }))


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

카테고리, 게시판 카테고리(서브 카테고리) api 적용

## 📋 작업 내용

카테고리, 게시판 카테고리(서브 카테고리) api 적용해서 항목 받아오도록 수정했습니다.
- 글쓰기 페이지에서 제목, 카테고리, 글 작성 후 등록하기 버튼 클릭 -> 미리보기 페이지에서 썸네일과 글 제목, 카테고리 선택 내용, 글 내용이 상태로 전달됨 
- 미리보기 페이지에서 업로드 버튼 클릭 시 상태에 저장된 데이터들을 서버로 보내줘야합니다.

## 🔧 변경 사항

useWriteStore에 카테고리 상태 추가

## 📸 스크린샷 
![스크린샷 2024-10-17 오후 6 01 39](https://github.com/user-attachments/assets/d0854967-ea60-438a-9567-849f269380c4)

![스크린샷 2024-10-17 오후 6 00 47](https://github.com/user-attachments/assets/50b7e4df-aa54-4a9a-94b3-7b0f9769ff30)




## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
