### PR TITLE
[Feat] 글쓰기 임시저장 기능 구현

### DIFF
--- a/src/hooks/useWrite.ts
+++ b/src/hooks/useWrite.ts
@@ -5,6 +5,7 @@ export default function useWrite() {
 	const markdownTitle = useWriteStore((state) => state.title)
 	const categories = useWriteStore((state) => state.category)
 	const boardId = useWriteStore((state) => state.boardId)
+	const thumbnail = useWriteStore((state) => state.thumbnailImg)
 	const setTitle = useWriteStore((state) => state.setTitle)
 	const setContent = useWriteStore((state) => state.setContent)
 	const setThumbnail = useWriteStore((state) => state.setThumbnail)
@@ -14,6 +15,7 @@ export default function useWrite() {
 		markdownContent,
 		markdownTitle,
 		categories,
+		thumbnail,
 		boardId,
 		setTitle,
 		setContent,

--- a/src/stores/writeStore.ts
+++ b/src/stores/writeStore.ts
@@ -1,4 +1,4 @@
-import { boardProps, categoryProps } from '@components/SelectBox'
+import { categoryProps } from '@components/SelectBox'
 import { create } from 'zustand'
 
 interface writeState {
@@ -6,12 +6,12 @@ interface writeState {
 	thumbnailImg: string
 	content: string
 	category: categoryProps[]
-	boardId: string
+	boardId: number
 	setTitle: (newTitle: string) => void
 	setThumbnail: (newContent: string) => void
 	setContent: (newContent: string) => void
 	setCategory: (newCategory: categoryProps[]) => void
-	setBoardId: (newBoard: string) => void
+	setBoardId: (newBoard: number) => void
 }
 
 export const useWriteStore = create<writeState>((set) => ({
@@ -19,7 +19,7 @@ export const useWriteStore = create<writeState>((set) => ({
 	thumbnailImg: '',
 	content: '',
 	category: [],
-	boardId: '',
+	boardId: 0,
 	setTitle: (newTitle) => set({ title: newTitle }),
 	setContent: (newContent) => set({ content: newContent }),
 	setThumbnail: (newContent) => {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

글쓰기 임시저장 로직 구현

## 📋 작업 내용

글쓰기 페이지에서 임시저장 클릭 시 임시저장 데이터 서버로 전송
(임시저장 성공, 실패 알림 필요해보임)

## 🔧 변경 사항

zustand store 내 boardId 자료형 string => number로 수정

## 📸 스크린샷 (선택 사항)
![스크린샷 2024-10-22 오후 5 22 02](https://github.com/user-attachments/assets/6d485e4a-828c-458c-81c3-d393f7ce43e2)

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
