### PR TITLE
[Feature] 미리보기 페이지 기능 구현

### DIFF
--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -14,6 +14,7 @@ export function ShowToast(message: string, toastType = 'success') {
 	} else {
 		toast.error(`${message}`, {
 			autoClose: 2000,
+			theme: 'dark',
 			draggable: true,
 		})
 	}

--- a/src/hooks/useWrite.ts
+++ b/src/hooks/useWrite.ts
@@ -13,6 +13,16 @@ export default function useWrite() {
 	const setCategories = useWriteStore((state) => state.setCategory)
 	const setBoardId = useWriteStore((state) => state.setBoardId)
 	const setDescription = useWriteStore((state) => state.setDescription)
+
+	const reset = () => {
+		setTitle('')
+		setContent('')
+		setThumbnail('')
+		setDescription('')
+		setCategories([])
+		setBoardId(0)
+	}
+
 	return {
 		markdownContent,
 		markdownTitle,
@@ -26,5 +36,6 @@ export default function useWrite() {
 		setCategories,
 		setBoardId,
 		setDescription,
+		reset,
 	}
 }

--- a/src/hooks/useWrite.ts
+++ b/src/hooks/useWrite.ts
@@ -6,21 +6,25 @@ export default function useWrite() {
 	const categories = useWriteStore((state) => state.category)
 	const boardId = useWriteStore((state) => state.boardId)
 	const thumbnail = useWriteStore((state) => state.thumbnailImg)
+	const description = useWriteStore((state) => state.description)
 	const setTitle = useWriteStore((state) => state.setTitle)
 	const setContent = useWriteStore((state) => state.setContent)
 	const setThumbnail = useWriteStore((state) => state.setThumbnail)
 	const setCategories = useWriteStore((state) => state.setCategory)
 	const setBoardId = useWriteStore((state) => state.setBoardId)
+	const setDescription = useWriteStore((state) => state.setDescription)
 	return {
 		markdownContent,
 		markdownTitle,
 		categories,
 		thumbnail,
 		boardId,
+		description,
 		setTitle,
 		setContent,
 		setThumbnail,
 		setCategories,
 		setBoardId,
+		setDescription,
 	}
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,8 +2,4 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 
-createRoot(document.getElementById('root')!).render(
-	<StrictMode>
-		<App />
-	</StrictMode>,
-)
+createRoot(document.getElementById('root')!).render(<App />)

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -8,14 +8,12 @@ import { type FileContent, useCoteData } from '@/hooks/useCoteData'
 import { formatDate } from '@/utils/formatDate'
 import { useParams } from 'react-router-dom'
 import { useEffect, useState } from 'react'
-import useWrite from '@/hooks/useWrite'
 import Toast from '@components/Toast'
 
 const PostDetail = () => {
 	const { title, author } = useParams()
 	const { commitData } = useCoteData()
 	const [coteData, setCoteData] = useState<FileContent[]>([])
-	const { markdownTitle, markdownContent } = useWrite()
 
 	useEffect(() => {
 		if (commitData.length) {

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -9,6 +9,7 @@ import { formatDate } from '@/utils/formatDate'
 import { useParams } from 'react-router-dom'
 import { useEffect, useState } from 'react'
 import useWrite from '@/hooks/useWrite'
+import Toast from '@components/Toast'
 
 const PostDetail = () => {
 	const { title, author } = useParams()
@@ -27,6 +28,7 @@ const PostDetail = () => {
 
 	return (
 		<Container>
+			<Toast />
 			<FloatingMenu />
 			{coteData.map((data) => (
 				<Wrapper key={`${data.title}-${data.author}`}>

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -8,11 +8,13 @@ import { type FileContent, useCoteData } from '@/hooks/useCoteData'
 import { formatDate } from '@/utils/formatDate'
 import { useParams } from 'react-router-dom'
 import { useEffect, useState } from 'react'
+import useWrite from '@/hooks/useWrite'
 
 const PostDetail = () => {
 	const { title, author } = useParams()
 	const { commitData } = useCoteData()
 	const [coteData, setCoteData] = useState<FileContent[]>([])
+	const { markdownTitle, markdownContent } = useWrite()
 
 	useEffect(() => {
 		if (commitData.length) {

--- a/src/pages/PreviewPage.tsx
+++ b/src/pages/PreviewPage.tsx
@@ -21,6 +21,7 @@ const PreviewPage = () => {
 		description,
 		setThumbnail,
 		setDescription,
+		reset,
 	} = useWrite()
 	const { userId } = useAuthStore()
 	const { uploadFile } = useFileUpload()
@@ -75,6 +76,7 @@ const PreviewPage = () => {
 				`/postDetail/${boardId === 0 ? '코딩테스트' : '스터디'}/@${userId}/${encodeURIComponent(markdownTitle)}`,
 			)
 			ShowToast('게시물이 성공적으로 등록되었습니다.', 'success')
+			reset()
 		} catch (error) {
 			console.log('미리보기페이지 등록 에러 .................', error)
 		}

--- a/src/pages/PreviewPage.tsx
+++ b/src/pages/PreviewPage.tsx
@@ -1,17 +1,44 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import styled from '@emotion/styled'
 import { ImagePlus } from 'lucide-react'
 import colors from '@/constants/color'
 import { fontSize, fontWeight } from '@/constants/font'
 import Button from '@components/Button'
-import { useWriteStore } from '@/stores/writeStore'
 import useGoBack from '@/hooks/useGoBack'
+import useWrite from '@/hooks/useWrite'
+import useFileUpload from '@/hooks/useFileUpload'
 
 const PreviewPage = () => {
-	const title = useWriteStore((state) => state.title)
-	const content = useWriteStore((state) => state.content)
-	const thumbnail = useWriteStore((state) => state.thumbnailImg)
+	const { markdownTitle, markdownContent, thumbnail, boardId, description, setThumbnail } =
+		useWrite()
+	const { uploadFile } = useFileUpload()
+	const fileRef = useRef<HTMLInputElement>(null)
+
 	const handleBack = useGoBack()
+
+	const handleThumnaileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+		const file = e.target.files?.[0]
+		if (file) {
+			const res = await uploadFile(file)
+			setThumbnail(`![](${res.baseUrl + res.fileName})`)
+		}
+	}
+
+	const handleThumnailReupload = () => {
+		if (fileRef.current) {
+			fileRef.current.click()
+		}
+	}
+
+	const handleThumnailDelete = () => {
+		setThumbnail('')
+	}
+
+	console.log('썸네일url-------->', thumbnail)
+	console.log('Title---------->', markdownTitle)
+	console.log('내용--------->', markdownContent)
+	console.log('게시판 id---------->', boardId)
+	console.log('설명--------->', description)
 
 	return (
 		<Container>
@@ -19,8 +46,15 @@ const PreviewPage = () => {
 			<PreviewContainer>
 				<ThumnailContainer>
 					<div className="image-span">
-						<span>재업로드</span>
-						<span>제거</span>
+						<span onClick={handleThumnailReupload}>재업로드</span>
+						<input
+							type="file"
+							accept="image/*"
+							ref={fileRef}
+							style={{ display: 'none' }}
+							onChange={handleThumnaileChange}
+						/>
+						<span onClick={handleThumnailDelete}>제거</span>
 					</div>
 					<div
 						className="thumnail-upload"
@@ -30,23 +64,30 @@ const PreviewPage = () => {
 							backgroundPosition: 'center',
 						}}
 					>
-						{!thumbnail ? (
-							<ImagePlus size={200} strokeWidth={1} color={colors.deleteGray} />
-						) : (
-							<form>
-								<label htmlFor="thumbnailImg" className="img-label">
-									썸네일 업로드
-								</label>
-								<input type="file" accept="image/*" id="thumbnailImg" className="img-input" />
-							</form>
+						{!thumbnail && (
+							<>
+								<ImagePlus size={200} strokeWidth={1} color={colors.deleteGray} />
+								<form>
+									<label htmlFor="thumbnailImg" className="img-label">
+										썸네일 업로드
+									</label>
+									<input
+										type="file"
+										accept="image/*"
+										id="thumbnailImg"
+										className="img-input"
+										onChange={handleThumnaileChange}
+									/>
+								</form>
+							</>
 						)}
 					</div>
 				</ThumnailContainer>
 				<Line />
 				<PostPreviewContainer>
-					<div className="post-title">{title}</div>
-					<textarea defaultValue={content} className="post-content" />
-					<span className="count">{content.length}/150</span>
+					<div className="post-title">{markdownTitle}</div>
+					<textarea defaultValue={description} className="post-content" />
+					<span className="count">{description.length}/150</span>
 				</PostPreviewContainer>
 			</PreviewContainer>
 			<ButtonContainer>
@@ -82,6 +123,7 @@ const PreviewContainer = styled.div`
 `
 
 const ThumnailContainer = styled.div`
+	position: relative;
 	.thumnail-upload {
 		width: 456px;
 		height: 260px;
@@ -93,9 +135,10 @@ const ThumnailContainer = styled.div`
 	}
 
 	.image-span {
-		text-align: right;
+		position: absolute;
+		top: -30px;
+		left: 350px;
 		color: ${colors.commentGray};
-		margin-bottom: 10px;
 
 		span {
 			margin-left: 10px;
@@ -135,12 +178,14 @@ const Line = styled.div`
 `
 
 const PostPreviewContainer = styled.div`
-	margin-top: 10px;
+	position: relative;
+
 	.post-title {
+		position: absolute;
+		top: -50px;
 		font-size: ${fontSize.xxxl};
 		font-weight: ${fontWeight.bold};
 		color: #d9d9d9;
-		margin-bottom: 18px;
 	}
 
 	.post-content {
@@ -154,8 +199,10 @@ const PostPreviewContainer = styled.div`
 	}
 
 	.count {
+		position: absolute;
+		right: 0;
+		bottom: -30px;
 		display: block;
-		margin-top: 10px;
 		text-align: right;
 		color: ${colors.commentGray};
 	}
@@ -163,7 +210,9 @@ const PostPreviewContainer = styled.div`
 
 const ButtonContainer = styled.div`
 	width: 970px;
-	display: inline;
+	display: flex;
+	justify-content: end;
 	text-align: right;
+	gap: 10px;
 `
 export default PreviewPage

--- a/src/pages/PreviewPage.tsx
+++ b/src/pages/PreviewPage.tsx
@@ -9,6 +9,8 @@ import useWrite from '@/hooks/useWrite'
 import useFileUpload from '@/hooks/useFileUpload'
 import { useNavigate } from 'react-router-dom'
 import { useAuthStore } from '@/stores/authStore'
+import axios from 'axios'
+import { ShowToast } from '@components/Toast'
 
 const PreviewPage = () => {
 	const {
@@ -24,6 +26,7 @@ const PreviewPage = () => {
 	const { uploadFile } = useFileUpload()
 	const fileRef = useRef<HTMLInputElement>(null)
 	const navigate = useNavigate()
+	const { sessionId } = useAuthStore()
 
 	const handleBack = useGoBack()
 
@@ -49,10 +52,32 @@ const PreviewPage = () => {
 		setDescription(e.target.value)
 	}
 
-	const handleSubmit = () => {
-		navigate(
-			`/postDetail/${boardId === 0 ? '코딩테스트' : '스터디'}/@${userId}/${encodeURIComponent(markdownTitle)}`,
-		)
+	const handleSubmit = async () => {
+		try {
+			await axios.post(
+				'http://nubble-backend-eb-1-env.eba-f5sb82hp.ap-northeast-2.elasticbeanstalk.com/posts',
+				{
+					title: markdownTitle,
+					content: markdownContent,
+					boardId,
+					status: 'PUBLISHED',
+					thumbnailUrl: thumbnail,
+					description,
+				},
+				{
+					headers: {
+						'Content-Type': 'application/json',
+						'SESSION-ID': sessionId,
+					},
+				},
+			)
+			navigate(
+				`/postDetail/${boardId === 0 ? '코딩테스트' : '스터디'}/@${userId}/${encodeURIComponent(markdownTitle)}`,
+			)
+			ShowToast('게시물이 성공적으로 등록되었습니다.', 'success')
+		} catch (error) {
+			console.log('미리보기페이지 등록 에러 .................', error)
+		}
 	}
 
 	return (

--- a/src/pages/PreviewPage.tsx
+++ b/src/pages/PreviewPage.tsx
@@ -7,12 +7,23 @@ import Button from '@components/Button'
 import useGoBack from '@/hooks/useGoBack'
 import useWrite from '@/hooks/useWrite'
 import useFileUpload from '@/hooks/useFileUpload'
+import { useNavigate } from 'react-router-dom'
+import { useAuthStore } from '@/stores/authStore'
 
 const PreviewPage = () => {
-	const { markdownTitle, markdownContent, thumbnail, boardId, description, setThumbnail } =
-		useWrite()
+	const {
+		markdownTitle,
+		markdownContent,
+		thumbnail,
+		boardId,
+		description,
+		setThumbnail,
+		setDescription,
+	} = useWrite()
+	const { userId } = useAuthStore()
 	const { uploadFile } = useFileUpload()
 	const fileRef = useRef<HTMLInputElement>(null)
+	const navigate = useNavigate()
 
 	const handleBack = useGoBack()
 
@@ -34,11 +45,15 @@ const PreviewPage = () => {
 		setThumbnail('')
 	}
 
-	console.log('썸네일url-------->', thumbnail)
-	console.log('Title---------->', markdownTitle)
-	console.log('내용--------->', markdownContent)
-	console.log('게시판 id---------->', boardId)
-	console.log('설명--------->', description)
+	const onChangeTextarea = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+		setDescription(e.target.value)
+	}
+
+	const handleSubmit = () => {
+		navigate(
+			`/postDetail/${boardId === 0 ? '코딩테스트' : '스터디'}/@${userId}/${encodeURIComponent(markdownTitle)}`,
+		)
+	}
 
 	return (
 		<Container>
@@ -86,7 +101,12 @@ const PreviewPage = () => {
 				<Line />
 				<PostPreviewContainer>
 					<div className="post-title">{markdownTitle}</div>
-					<textarea defaultValue={description} className="post-content" />
+					<textarea
+						placeholder="게시글 요약을 써주세요."
+						value={description}
+						onChange={onChangeTextarea}
+						className="post-content"
+					/>
 					<span className="count">{description.length}/150</span>
 				</PostPreviewContainer>
 			</PreviewContainer>
@@ -94,7 +114,9 @@ const PreviewPage = () => {
 				<Button variant="secondary" radius={50} onClick={handleBack}>
 					취소
 				</Button>
-				<Button radius={50}>등록하기</Button>
+				<Button radius={50} onClick={handleSubmit}>
+					등록하기
+				</Button>
 			</ButtonContainer>
 		</Container>
 	)

--- a/src/pages/WritePage.tsx
+++ b/src/pages/WritePage.tsx
@@ -57,6 +57,7 @@ const WritePage = () => {
 		setThumbnail,
 		setCategories,
 		setBoardId,
+		setDescription,
 	} = useWrite()
 	const { sessionId } = useAuthStore()
 
@@ -143,8 +144,9 @@ const WritePage = () => {
 
 	const handleSubmit = () => {
 		setTitle(markdownTitle)
-		setContent(markdownContent.slice(0, 150))
+		setContent(markdownContent)
 		setThumbnail(markdownContent)
+		setDescription(markdownContent)
 		navigate('/preview')
 	}
 

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -23,7 +23,7 @@ export const router = createBrowserRouter([
 				path: '/login',
 				element: <Login />, // 로그인 페이지 (헤더 없음)
 			},
-			{ path: '/postDetail/:author/:title', element: <PostDetail /> },
+			{ path: '/postDetail/:category/:author/:title', element: <PostDetail /> },
 			{
 				path: '/saves',
 				element: <Saves />,

--- a/src/stores/writeStore.ts
+++ b/src/stores/writeStore.ts
@@ -5,11 +5,13 @@ interface writeState {
 	title: string
 	thumbnailImg: string
 	content: string
+	description: string
 	category: categoryProps[]
 	boardId: number
 	setTitle: (newTitle: string) => void
 	setThumbnail: (newContent: string) => void
 	setContent: (newContent: string) => void
+	setDescription: (newDescription: string) => void
 	setCategory: (newCategory: categoryProps[]) => void
 	setBoardId: (newBoard: number) => void
 }
@@ -18,6 +20,7 @@ export const useWriteStore = create<writeState>((set) => ({
 	title: '',
 	thumbnailImg: '',
 	content: '',
+	description: '',
 	category: [],
 	boardId: 0,
 	setTitle: (newTitle) => set({ title: newTitle }),
@@ -32,6 +35,7 @@ export const useWriteStore = create<writeState>((set) => ({
 			return state
 		})
 	},
+	setDescription: (newDescription) => set({ description: newDescription.slice(0, 150) }),
 	setCategory: (newCategory) =>
 		set((state) => {
 			return { ...state, category: newCategory }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

미리보기 페이지 기능 구현

## 📋 작업 내용

- 썸네일 없을시 업로드, 재업로드 , 제거 기능
- 게시글 등록 api 연동
- url 경로 변경
- 토스트 추가
- 등록하기 버튼 클릭 시 zustand writeStore 상태값 초기화

## 🔧 변경 사항

- postDetail url 경로 변경
```tsx
 { path: '/postDetail/:category/:author/:title', element: <PostDetail /> }
```

## 📸 스크린샷 (선택 사항)

![Oct-23-2024 23-40-09](https://github.com/user-attachments/assets/7ef218d5-dcbe-4351-912e-2c9cf8636372)


## 📄 기타

추후 textarea에 이미지 url 그대로 들어가는거 수정 예정
