### PR TITLE
[Fix] 글쓰기 페이지 수정

### DIFF
--- a/src/components/SelectBox.tsx
+++ b/src/components/SelectBox.tsx
@@ -3,12 +3,12 @@ import styled from '@emotion/styled'
 import colors from '@/constants/color'
 
 export interface categoryProps {
-	categoryId: string
+	categoryId: number
 	categoryName: string
 }
 
 export interface boardProps {
-	id: string
+	id: number
 	name: string
 }
 
@@ -16,7 +16,7 @@ interface SelectBoxProps {
 	label?: string
 	options: categoryProps[] | boardProps[]
 	placeholder?: string
-	selectedValue: string
+	selectedValue?: string
 	disabled?: boolean
 	handleChange: (e: ChangeEvent<HTMLSelectElement>) => void
 }
@@ -32,8 +32,12 @@ const SelectBox = ({
 	return (
 		<div>
 			{label && <Label>{label}</Label>}
-			<Select value={selectedValue} onChange={handleChange} disabled={disabled}>
-				<Option value="">{placeholder}</Option>
+			<Select value={selectedValue || ''} onChange={handleChange} disabled={disabled}>
+				{!selectedValue && (
+					<Option value="" disabled>
+						{placeholder}
+					</Option>
+				)}
 				{options.map((option) => (
 					<option
 						key={

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -27,5 +27,6 @@ export default function Toast() {
 export const StyledToastContainer = styled(ToastContainer)`
 	.Toastify__toast {
 		background-color: #3d3d3d;
+		color: #ffffff;
 	}
 `

--- a/src/hooks/useCategory.ts
+++ b/src/hooks/useCategory.ts
@@ -1,23 +1,65 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
+import axios from 'axios'
+import { useWriteStore } from '@/stores/writeStore'
 
 const useCategory = () => {
-	const [selectedCategory, setSelectedCategory] = useState<string>('')
-	const [selectedSubCategory, setSelectedSubCategory] = useState<string>('')
+	const category = useWriteStore((state) => state.category)
+	const setCategory = useWriteStore((state) => state.setCategory)
+	const board = useWriteStore((state) => state.board)
+	const setBoard = useWriteStore((state) => state.setBoard)
+	const [categories, setCategories] = useState([])
+	const [boards, setBoards] = useState([])
+
+	const fetchCategory = async () => {
+		const res = await axios.get(`${import.meta.env.VITE_NUBBLE_SERVER}/categories`, {
+			headers: {
+				'Content-Type': 'application/json',
+			},
+		})
+		setCategories(res.data.categories)
+	}
+
+	const fetchBoards = async (categoryId: string) => {
+		const res = await axios.get(
+			`${import.meta.env.VITE_NUBBLE_SERVER}/categories/${categoryId}/boards`,
+			{
+				headers: {
+					'Content-Type': 'application/json',
+				},
+			},
+		)
+		setBoards(res.data.boards)
+	}
 
 	const handleSelectedData = (e: React.ChangeEvent<HTMLSelectElement>) => {
-		setSelectedCategory(e.target.value)
-		setSelectedSubCategory('')
+		if (e.target.value) {
+			setCategory(e.target.value)
+			fetchBoards(e.target.value)
+		}
 	}
 
 	const handleSubData = (e: React.ChangeEvent<HTMLSelectElement>) => {
-		setSelectedSubCategory(e.target.value)
+		setBoard(e.target.value)
 	}
 
+	useEffect(() => {
+		fetchCategory()
+	}, [])
+
+	useEffect(() => {
+		if (category) {
+			fetchBoards(category)
+		}
+	}, [category])
+
 	return {
-		selectedCategory,
-		selectedSubCategory,
-		setSelectedCategory,
-		setSelectedSubCategory,
+		category,
+		board,
+		categories,
+		boards,
+		setCategory,
+		setBoard,
+		fetchBoards,
 		handleSelectedData,
 		handleSubData,
 	}

--- a/src/hooks/useWrite.ts
+++ b/src/hooks/useWrite.ts
@@ -3,14 +3,16 @@ import { useWriteStore } from '@/stores/writeStore'
 export default function useWrite() {
 	const markdownContent = useWriteStore((state) => state.content)
 	const markdownTitle = useWriteStore((state) => state.title)
-	const categories = useWriteStore((state) => state.category)
+	const category = useWriteStore((state) => state.category)
+	const board = useWriteStore((state) => state.board)
 	const boardId = useWriteStore((state) => state.boardId)
 	const thumbnail = useWriteStore((state) => state.thumbnailImg)
 	const description = useWriteStore((state) => state.description)
 	const setTitle = useWriteStore((state) => state.setTitle)
 	const setContent = useWriteStore((state) => state.setContent)
 	const setThumbnail = useWriteStore((state) => state.setThumbnail)
-	const setCategories = useWriteStore((state) => state.setCategory)
+	const setCategory = useWriteStore((state) => state.setCategory)
+	const setBoard = useWriteStore((state) => state.setBoard)
 	const setBoardId = useWriteStore((state) => state.setBoardId)
 	const setDescription = useWriteStore((state) => state.setDescription)
 
@@ -19,21 +21,24 @@ export default function useWrite() {
 		setContent('')
 		setThumbnail('')
 		setDescription('')
-		setCategories([])
+		setCategory('')
+		setBoard('')
 		setBoardId(0)
 	}
 
 	return {
 		markdownContent,
 		markdownTitle,
-		categories,
+		category,
 		thumbnail,
+		board,
 		boardId,
 		description,
 		setTitle,
 		setContent,
 		setThumbnail,
-		setCategories,
+		setCategory,
+		setBoard,
 		setBoardId,
 		setDescription,
 		reset,

--- a/src/pages/WritePage.tsx
+++ b/src/pages/WritePage.tsx
@@ -13,28 +13,7 @@ import useFileUpload from '@/hooks/useFileUpload'
 import { useWriteStore } from '@/stores/writeStore'
 import useWrite from '@/hooks/useWrite'
 import { useAuthStore } from '@/stores/authStore'
-
-interface Post {
-	markdownTitle: string
-	content: string
-	category: string
-	subCategory: string
-}
-
-const postsData: Record<string, Post> = {
-	1: {
-		markdownTitle: '나는 1번이다',
-		content: '나는 1번이다 이건 테스트임',
-		category: 'study',
-		subCategory: 'cs',
-	},
-	2: {
-		markdownTitle: '나는 2번이다',
-		content: '나는 2번이다 이건 아까와 똑같은 테스트임',
-		category: 'study',
-		subCategory: 'cs',
-	},
-}
+import { toast } from 'react-toastify'
 
 const WritePage = () => {
 	const navigate = useNavigate()
@@ -44,21 +23,28 @@ const WritePage = () => {
 	const fileRef = useRef<HTMLInputElement>(null)
 	const readRef = useRef<HTMLDivElement>(null)
 	const [isEditing, setIsEditing] = useState(false)
-	const { selectedCategory, selectedSubCategory, handleSelectedData, handleSubData } = useCategory()
-	const { uploadFile } = useFileUpload()
-	const [boards, setBoards] = useState([])
+	const {
+		categories,
+		boards,
+		category,
+		board,
+		setCategory,
+		setBoard,
+		handleSelectedData,
+		handleSubData,
+	} = useCategory()
 	const {
 		markdownContent,
 		markdownTitle,
-		categories,
 		boardId,
 		setTitle,
 		setContent,
 		setThumbnail,
-		setCategories,
 		setBoardId,
 		setDescription,
+		reset,
 	} = useWrite()
+	const { uploadFile } = useFileUpload()
 	const { sessionId } = useAuthStore()
 
 	const handleUploadFile = () => {
@@ -111,32 +97,8 @@ const WritePage = () => {
 	}
 
 	const handleBack = () => {
-		setTitle('')
-		setContent('')
-		setThumbnail('')
-
+		reset()
 		navigate(-1)
-	}
-
-	const fetchCategory = async () => {
-		const res = await axios.get(`${import.meta.env.VITE_NUBBLE_SERVER}/categories`, {
-			headers: {
-				'Content-Type': 'application/json',
-			},
-		})
-		setCategories(res.data.categories)
-	}
-
-	const fetchBoards = async (categoryId: string) => {
-		const res = await axios.get(
-			`${import.meta.env.VITE_NUBBLE_SERVER}/categories/${categoryId}/boards`,
-			{
-				headers: {
-					'Content-Type': 'application/json',
-				},
-			},
-		)
-		setBoards(res.data.boards)
 	}
 
 	const handleSubmit = () => {
@@ -144,6 +106,8 @@ const WritePage = () => {
 		setContent(markdownContent)
 		setThumbnail(markdownContent)
 		setDescription(markdownContent)
+		setCategory(category)
+		setBoard(board)
 		navigate('/preview')
 	}
 
@@ -165,13 +129,12 @@ const WritePage = () => {
 					},
 				},
 			)
+			toast.success('임시저장이 완료되었습니다.✨')
 			return res
 		} catch (error) {
-			//임시저장 실패, 성공시 알림 모달 또는 토스트 알림 필요해보임
-			console.log('수정하기 에러', error)
+			toast.error('임시저장에 실패했는데요?😱')
 		}
 	}
-
 	// useEffect(() => {
 	// 	if (id) {
 	// 		setIsEditing(true)
@@ -186,15 +149,10 @@ const WritePage = () => {
 	// }, [id])
 
 	useEffect(() => {
-		fetchCategory()
-	}, [])
-
-	useEffect(() => {
-		if (selectedCategory) {
-			fetchBoards(selectedCategory)
-			setBoardId(Number(selectedCategory))
+		if (category) {
+			setBoardId(Number(category))
 		}
-	}, [selectedCategory])
+	}, [category])
 
 	return (
 		<Container>
@@ -222,16 +180,16 @@ const WritePage = () => {
 					<div className="select-category">
 						<SelectBox
 							options={categories}
-							selectedValue={selectedCategory}
+							selectedValue={category}
 							placeholder="카테고리 선택"
 							handleChange={handleSelectedData}
 						/>
 						<SelectBox
 							options={boards}
-							selectedValue={selectedSubCategory}
+							selectedValue={board}
 							placeholder="내용 선택"
 							handleChange={handleSubData}
-							disabled={!selectedCategory}
+							disabled={boards.length === 0 || !category}
 						/>
 					</div>
 				</div>
@@ -252,7 +210,7 @@ const WritePage = () => {
 							variant="secondary"
 							radius={50}
 							onClick={handleDraft}
-							disabled={!(markdownTitle && markdownContent)}
+							disabled={!(markdownTitle && markdownContent && category && board)}
 						>
 							임시저장
 						</Button>
@@ -262,7 +220,7 @@ const WritePage = () => {
 							<Button
 								radius={50}
 								onClick={handleSubmit}
-								disabled={!(markdownTitle && markdownContent)}
+								disabled={!(markdownTitle && markdownContent && category && board)}
 							>
 								등록하기
 							</Button>

--- a/src/pages/WritePage.tsx
+++ b/src/pages/WritePage.tsx
@@ -14,6 +14,7 @@ import { useWriteStore } from '@/stores/writeStore'
 import useWrite from '@/hooks/useWrite'
 import { useAuthStore } from '@/stores/authStore'
 import { toast } from 'react-toastify'
+import Toast from '@components/Toast'
 
 const WritePage = () => {
 	const navigate = useNavigate()
@@ -156,6 +157,7 @@ const WritePage = () => {
 
 	return (
 		<Container>
+			<Toast />
 			<div className="area-write">
 				<input
 					className="write-markdownTitle"

--- a/src/stores/writeStore.ts
+++ b/src/stores/writeStore.ts
@@ -1,4 +1,3 @@
-import { categoryProps } from '@components/SelectBox'
 import { create } from 'zustand'
 
 interface writeState {
@@ -6,13 +5,15 @@ interface writeState {
 	thumbnailImg: string
 	content: string
 	description: string
-	category: categoryProps[]
+	category: string
+	board: string
 	boardId: number
 	setTitle: (newTitle: string) => void
 	setThumbnail: (newContent: string) => void
 	setContent: (newContent: string) => void
 	setDescription: (newDescription: string) => void
-	setCategory: (newCategory: categoryProps[]) => void
+	setCategory: (newCategory: string) => void
+	setBoard: (newSubCategory: string) => void
 	setBoardId: (newBoard: number) => void
 }
 
@@ -21,7 +22,8 @@ export const useWriteStore = create<writeState>((set) => ({
 	thumbnailImg: '',
 	content: '',
 	description: '',
-	category: [],
+	category: '',
+	board: '',
 	boardId: 0,
 	setTitle: (newTitle) => set({ title: newTitle }),
 	setContent: (newContent) => set({ content: newContent }),
@@ -36,9 +38,11 @@ export const useWriteStore = create<writeState>((set) => ({
 		})
 	},
 	setDescription: (newDescription) => set({ description: newDescription.slice(0, 150) }),
-	setCategory: (newCategory) =>
-		set((state) => {
-			return { ...state, category: newCategory }
-		}),
+	setCategory: (newCategory) => {
+		set({ category: newCategory })
+	},
+	setBoard: (newSubCategory) => {
+		set({ board: newSubCategory })
+	},
 	setBoardId: (newBoard) => set({ boardId: newBoard }),
 }))


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

글쓰기 페이지 수정

## 🔧 변경 사항

임시저장 버튼 클릭 후 , 서버로 전송이 완료되면  완료 토스트 알림창이 뜨도록 수정했습니다.
제목, 내용, 카테고리 값 모두 입력 시 임시저장, 등록하기 버튼이 활성화 되도록 수정했습니다.
글쓰기 -> 미리보기 페이지로 이동 후 수정해야할 사항이 있어 다시 글쓰기 페이지로 돌아갔을 때  카테고리 상태값이 초기화 되는 이슈를 수정하였습니다.

## 📸 스크린샷 (선택 사항)
![Oct-24-2024 14-36-56](https://github.com/user-attachments/assets/bbedd529-fa27-4363-a88c-ff3a8088b7cc)


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
