### PR TITLE
[Fix] 댓글관련 수정사항들

### DIFF
--- a/src/components/comment/CommentList.tsx
+++ b/src/components/comment/CommentList.tsx
@@ -9,6 +9,7 @@ import { formatDate } from '@/utils/formatDate'
 import { useAuthStore } from '@/stores/authStore'
 import useModalStore from '@/stores/modalStore'
 import Modal from '@components/Modal'
+import { ShowToast } from '@components/Toast'
 
 interface Comment {
 	commentId: number
@@ -59,12 +60,14 @@ const CommentList = () => {
 									headers: { 'SESSION-ID': sessionId },
 								},
 							)
+							ShowToast('댓글이 삭제되었습니다.', 'success')
 							// 삭제 후 상태 업데이트
 							setCommentsData((prevComments) =>
 								prevComments.filter((comment) => comment.commentId !== commentId),
 							)
 						} catch (error) {
 							console.error('댓글 삭제 중 에러 발생:', error)
+							ShowToast('댓글 삭제 중 오류가 발생했습니다.', 'failed')
 						}
 					},
 				})
@@ -87,8 +90,9 @@ const CommentList = () => {
 								setCommentsData((prevComments) =>
 									prevComments.filter((comment) => comment.commentId !== commentId),
 								)
+								ShowToast('댓글이 삭제되었습니다.', 'success')
 							} catch (error) {
-								console.error('댓글 삭제 중 에러 발생:', error)
+								ShowToast('비밀번호가 틀렸습니다.', 'failed')
 							}
 						},
 					})

--- a/src/pages/AddQuestion.tsx
+++ b/src/pages/AddQuestion.tsx
@@ -40,9 +40,13 @@ const AddQuestion = () => {
 	useEffect(() => {
 		const getCodingTestList = async () => {
 			try {
-				const res = await axios.get(`${import.meta.env.VITE_NUBBLE_SERVER}/coding-problems`)
-				const data = res.data.problems.map((problem: any) => ({
-					id: problem.problemId, // problemId 필드를 id로 저장
+				const res = await axios.get<{ problems: Question[] }>(
+					`${import.meta.env.VITE_NUBBLE_SERVER}/coding-problems`,
+				)
+
+				// ProblemResponse 배열을 Question 배열로 변환
+				const data: Question[] = res.data.problems.map((problem) => ({
+					id: problem.id,
 					quizDate: problem.quizDate,
 					problemTitle: problem.problemTitle,
 				}))


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

로그인했던 안했던 삭제버튼 눌렀을때 모달 뜨게하기
비로그인시 비밀번호 틀렸을 경우에 비밀번호 틀렸다는 토스트나 알림창 띄우게하기
댓글 삭제 성공,실패시 토스트창 알림
any타입 제거


## 📋 작업 내용

로그인했던 안했던 삭제버튼 눌렀을때 모달 뜨게하기
비로그인시 비밀번호 틀렸을 경우에 비밀번호 틀렸다는 토스트나 알림창 띄우게하기
댓글 삭제 성공,실패시 토스트창 알림
any타입 제거

## 🔧 변경 사항

로그인했던 안했던 삭제버튼 눌렀을때 모달 뜨게하기
비로그인시 비밀번호 틀렸을 경우에 비밀번호 틀렸다는 토스트나 알림창 띄우게하기
댓글 삭제 성공,실패시 토스트창 알림
any타입 제거

## 📸 스크린샷 (선택 사항)

![image](https://github.com/user-attachments/assets/b1d74c64-a83e-4891-9ddc-65fb7f2ce114)
![image](https://github.com/user-attachments/assets/8e2de232-010c-47b2-9f6f-86257b4358d6)

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
